### PR TITLE
Prepare 0.150.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,23 @@ members = [
     "crates/*"
 ]
 resolver = "2"
+
+[workspace.package]
+# All the packages in the workspace should have the same version
+version = "0.150.4"
+
+[workspace.dependencies]
+# Local dependencies
+bindings-generator = { version = "=0.150.4", path = "crates/bindings-generator" }
+boojum-cuda = { version = "=0.150.4", path = "crates/boojum-cuda" }
+era_criterion_cuda = { version = "=0.150.4", path = "crates/criterion-cuda" }
+era_cudart = { version = "=0.150.4", path = "crates/cudart" }
+era_cudart_sys = { version = "=0.150.4", path = "crates/cudart-sys" }
+gpu-ffi = { version = "=0.150.4", path = "crates/gpu-ffi", package = "zksync-gpu-ffi" }
+gpu-prover = { version = "=0.150.4", path = "crates/gpu-prover", package = "zksync-gpu-prover" }
+shivini = { version = "=0.150.4", path = "crates/shivini" }
+wrapper-prover = { version = "=0.150.4", path = "crates/wrapper-prover", package = "zksync-wrapper-prover" }
+
+# These dependencies should be shared by all the crates.
+circuit_definitions = { version = "=0.150.4" }
+zkevm_test_harness = { version = "=0.150.4" }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+# Release process
+
+If you want to release the packages on crates.io, follow this process:
+
+1. Install `cargo workspaces`: `cargo install cargo-workspaces`
+2. Create a new branch to prepare a release.
+3. Change versions in the `Cargo.toml`:
+  - `version` in `[workspace.package]`
+  - `version` in `[workspace.dependencies]` for all the relevant crates.
+4. Run `cargo build`. It must succeed.
+5. Commit changes.
+6. Run `cargo ws publish --dry-run`. Check the output. It might fail, but it might be OK.
+  - `error: config value 'http.cainfo' is not set` can be ignored.
+  - There might be warnings, this is OK.
+  - There might be errors related to the version resolution, e.g. `failed to select a version`
+    (in particular, for `zkevm_test_harness`). It's due to a bug in cargo workspaces.
+    Check that the packages it complains about actually have the specified version, and if so,
+    it's safe to proceed.
+7. Create a PR named `crates.io: Release <version>`. Get a review and merge it.
+8. From the main branch _after_ you merge it, run `cargo ws publish --publish-as-is`.
+  - The `--publish-as-is` argument skips the versioning step, which you already did before.
+9. If something goes wrong, see recommendations below.
+10. If everything is OK, create a tag: `git tag v<version>`, e.g. `git tag v0.150.4`
+11. `git push --tags`
+12. Go to the Releases in the GitHUb, and create a release for published version.

--- a/crates/bindings-generator/Cargo.toml
+++ b/crates/bindings-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_cuda_bindings_generator"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -13,4 +13,4 @@ publish = false
 
 [dependencies]
 bindgen = "0.69"
-era_cudart_sys = { version = "=0.2.0", path = "../cudart-sys" }
+era_cudart_sys.workspace = true

--- a/crates/boojum-cuda/Cargo.toml
+++ b/crates/boojum-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boojum-cuda"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 build = "build/main.rs"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
@@ -13,21 +13,21 @@ description = "Boojum-CUDA is a library implementing GPU-accelerated cryptograph
 
 [build-dependencies]
 boojum = "=0.2.2"
-era_cudart_sys = { version = "=0.2.0", path = "../cudart-sys" }
+era_cudart_sys.workspace = true
 cmake = "0.1"
 itertools = "0.13"
 
 [dependencies]
 boojum = "=0.2.2"
-era_cudart = { version = "=0.2.0", path = "../cudart" }
-era_cudart_sys = { version = "=0.2.0", path = "../cudart-sys" }
+era_cudart.workspace = true
+era_cudart_sys.workspace = true
 itertools = "0.13"
 lazy_static = "1.4"
 
 [dev-dependencies]
 blake2 = "0.10"
 criterion = "0.5"
-era_criterion_cuda = { version = "=0.2.0", path = "../criterion-cuda" }
+era_criterion_cuda.workspace = true
 criterion-macro = "0.4"
 itertools = "0.13"
 rand = "0.8"

--- a/crates/criterion-cuda/Cargo.toml
+++ b/crates/criterion-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_criterion_cuda"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -9,7 +9,8 @@ license = "MIT OR Apache-2.0"
 keywords = ["blockchain", "zksync"]
 categories = ["cryptography"]
 description = "Criterion benchmarks support for CUDA event-based timings for ZKsync"
+publish = false
 
 [dependencies]
 criterion = "0.5"
-era_cudart = { version = "=0.2.0", path = "../cudart" }
+era_cudart.workspace = true

--- a/crates/cudart-sys/Cargo.toml
+++ b/crates/cudart-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_cudart_sys"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/crates/cudart/Cargo.toml
+++ b/crates/cudart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_cudart"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 description = "CUDA bindings for ZKsync"
 
 [dependencies]
-era_cudart_sys = { version = "=0.2.0", path = "../cudart-sys" }
+era_cudart_sys.workspace = true
 bitflags = "2.6"
 paste = "1.0"
 

--- a/crates/gpu-ffi/Cargo.toml
+++ b/crates/gpu-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync-gpu-ffi"
-version = "0.150.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/crates/gpu-prover/Cargo.toml
+++ b/crates/gpu-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync-gpu-prover"
-version = "0.150.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -13,12 +13,11 @@ description = "ZKsync GPU prover utilities"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gpu-ffi = { package = "zksync-gpu-ffi", version = "=0.150.0", path = "../gpu-ffi"}
+gpu-ffi.workspace = true
 crossbeam = "0.8"
 rand = "0.4"
 num_cpus = "1"
-franklin-crypto = { version = "=0.2.2", optional = true}
-# franklin-crypto = {path = "../../franklin-crypto", features = ["plonk"], optional = true}
+franklin-crypto = { version = "=0.2.2", optional = true }
 itertools = "0.10"
 cfg-if = "1"
 bit-vec = "0.6"

--- a/crates/shivini/Cargo.toml
+++ b/crates/shivini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shivini"
-version = "0.150.3"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -15,10 +15,10 @@ exclude = ["/test_data"]
 
 [dependencies]
 boojum = "=0.2.2"
-boojum-cuda = { version = "=0.2.0", path = "../boojum-cuda" }
-era_cudart = { version = "=0.2.0", path = "../cudart" }
-era_cudart_sys = { version = "=0.2.0", path = "../cudart-sys" }
-circuit_definitions = { version = "=0.150.2", package = "circuit_definitions", optional = true }
+boojum-cuda.workspace = true
+era_cudart.workspace = true
+era_cudart_sys.workspace = true
+circuit_definitions = { workspace = true, optional = true }
 
 rand = "0.8"
 smallvec = { version = "1.13", features = [

--- a/crates/wrapper-prover/Cargo.toml
+++ b/crates/wrapper-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync-wrapper-prover"
-version = "0.150.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -9,12 +9,11 @@ license = "MIT OR Apache-2.0"
 keywords = ["blockchain", "zksync"]
 categories = ["cryptography"]
 description = "ZKsync GPU wrapper prover"
+exclude = [ "test_proofs" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gpu-prover = { package = "zksync-gpu-prover", version = "=0.150.0", path = "../gpu-prover" }
-# zkevm_test_harness = {path = "../../era-zkevm_test_harness"}
-# circuit_definitions = {path = "../../era-zkevm_test_harness/circuit_definitions"}
-zkevm_test_harness = "=0.150.2"
-circuit_definitions = "=0.150.2"
+gpu-prover.workspace = true
+zkevm_test_harness.workspace = true
+circuit_definitions.workspace = true


### PR DESCRIPTION
# What ❔

Prepares 0.150.4 release.

- Bumped protocol deps.
- Set the `workspace.version` for every crate, so that it's defined in one place.
- Bump the version to `0.150.4`
- Add `RELEASE.md` with release instructions.
