### PR TITLE
optionally build bellman-cuda from source if no build is found

### DIFF
--- a/crates/gpu-ffi/Cargo.toml
+++ b/crates/gpu-ffi/Cargo.toml
@@ -20,7 +20,9 @@ num_cpus = "1"
 crossbeam = "0.8"
 
 [build-dependencies]
+era_cudart_sys.workspace = true
 bindgen = "0.59.1"
+cmake = "0.1"
 
 [dev-dependencies]
 rand = "0.4"


### PR DESCRIPTION
# What ❔

This PR makes it possible to compile `bellman-cuda` on the fly from source when building the `gpu-ffi` crate and a `bellman-cuda` build is not found.

## Why ❔

Makes it possible to compile `gpu-ffi` without building `bellman-cuda` by hand.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and linted via `cargo check`.
