### PR TITLE
fix(boojum-cuda): "un-swap" coarse and fine count for powers_data_g_i

### DIFF
--- a/crates/boojum-cuda/native/context.cuh
+++ b/crates/boojum-cuda/native/context.cuh
@@ -6,7 +6,7 @@ using namespace goldilocks;
 
 namespace goldilocks {
 
-static constexpr unsigned OMEGA_LOG_ORDER = 29;
+static constexpr unsigned OMEGA_LOG_ORDER = 24;
 
 struct powers_layer_data {
   const base_field *values;

--- a/crates/boojum-cuda/native/context.cuh
+++ b/crates/boojum-cuda/native/context.cuh
@@ -6,7 +6,7 @@ using namespace goldilocks;
 
 namespace goldilocks {
 
-static constexpr unsigned OMEGA_LOG_ORDER = 24;
+static constexpr unsigned OMEGA_LOG_ORDER = 29;
 
 struct powers_layer_data {
   const base_field *values;

--- a/crates/boojum-cuda/src/context.rs
+++ b/crates/boojum-cuda/src/context.rs
@@ -9,7 +9,7 @@ use era_cudart_sys::{cudaMemcpyToSymbol, cuda_struct_and_stub, CudaMemoryCopyKin
 use std::mem::size_of;
 use std::os::raw::c_void;
 
-pub const OMEGA_LOG_ORDER: u32 = 29;
+pub const OMEGA_LOG_ORDER: u32 = 24;
 
 #[repr(C)]
 struct PowersLayerData {

--- a/crates/boojum-cuda/src/context.rs
+++ b/crates/boojum-cuda/src/context.rs
@@ -9,7 +9,7 @@ use era_cudart_sys::{cudaMemcpyToSymbol, cuda_struct_and_stub, CudaMemoryCopyKin
 use std::mem::size_of;
 use std::os::raw::c_void;
 
-pub const OMEGA_LOG_ORDER: u32 = 24;
+pub const OMEGA_LOG_ORDER: u32 = 29;
 
 #[repr(C)]
 struct PowersLayerData {
@@ -132,9 +132,9 @@ unsafe fn copy_to_symbols(
         &powers_data_g_i,
         &PowersData::new(
             powers_of_g_i_fine,
-            coarse_log_count,
-            powers_of_g_i_coarse,
             fine_log_count,
+            powers_of_g_i_coarse,
+            coarse_log_count,
         ),
     )?;
     copy_to_symbol(&inv_sizes, &inv_sizes_host)?;


### PR DESCRIPTION
# What ❔

Fixes bug in context creation where `coarse_log_count` and `fine_log_count` were mistakenly swapped.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
