### PR TITLE
fix: Attempt to pin github runner to 22.04.1

### DIFF
--- a/.github/workflows/release-please-prepare-branch.yaml
+++ b/.github/workflows/release-please-prepare-branch.yaml
@@ -34,7 +34,7 @@ jobs:
           fi
     
   update_version:
-    runs-on: [ubuntu-22.04.1]
+    runs-on: [ubuntu-24.04]
     name: "release-please: Update version in Cargo.toml"
     needs: [check_state]
     if: ${{ needs.check_state.outputs.already_committed != 'true' }}


### PR DESCRIPTION
This is needed because release please is broken due to update on ubuntu latest.

You can see the working workflow [here](https://github.com/matter-labs/zksync-crypto-gpu/actions/runs/11272513297/job/31347594922) and the broken one [here](https://github.com/matter-labs/zksync-crypto-gpu/actions/runs/11386101382/job/31717991644?pr=32).

~~With update to 22.04.5, GLIBC was either updated to a higher version or linked under a different name.~~
Turns out it was 22.04.5 that rolled back from 24.04.1.

This change was NOT tested.
