### PR TITLE
Uninitialized data access issue fixed

### DIFF
--- a/crates/gpu-prover/src/cuda_bindings/device_arithmetic.rs
+++ b/crates/gpu-prover/src/cuda_bindings/device_arithmetic.rs
@@ -230,6 +230,8 @@ impl DeviceBuf<Fr> {
                     );
                     let constant = constant.expect("constant should be Some in SetValue operation");
 
+                    self.data_is_set = true;
+
                     ff_set_value(
                         self.as_mut_ptr(range) as *mut c_void,
                         &constant as *const Fr as *const c_void,
@@ -245,8 +247,10 @@ impl DeviceBuf<Fr> {
             return Err(GpuError::ArithmeticErr(result));
         }
 
+        assert!(self.data_is_set, "DeviceBuf should be filled with some data");
         self.write_event.record(&ctx.exec_stream)?;
         if let Some(other) = other {
+            assert!(other.data_is_set, "DeviceBuf should be filled with some data");
             other.read_event.record(&ctx.exec_stream)?;
         }
 
@@ -263,6 +267,8 @@ impl DeviceBuf<Fr> {
         shift: usize,
         inverse: bool,
     ) -> GpuResult<()> {
+        assert!(self.data_is_set, "DeviceBuf should be filled with some data");
+        
         assert!(
             ctx.ff,
             "ff is not set up on GpuContext with id {}",

--- a/crates/gpu-prover/src/cuda_bindings/device_heavy_ops.rs
+++ b/crates/gpu-prover/src/cuda_bindings/device_heavy_ops.rs
@@ -17,6 +17,8 @@ impl DeviceBuf<Fr> {
         let mut result = DeviceBuf::<G1>::async_alloc_in_exec(ctx, 254)?;
         ctx.exec_stream.wait(self.write_event())?;
 
+        assert!(self.data_is_set, "DeviceBuf should be filled with some data");
+
         let null_ptr = std::ptr::null_mut() as *mut c_void;
         let null_event = bc_event { handle: null_ptr };
 
@@ -44,6 +46,7 @@ impl DeviceBuf<Fr> {
 
         self.read_event.record(ctx.exec_stream())?;
         result.write_event.record(ctx.exec_stream())?;
+        result.data_is_set = true;
 
         Ok(result)
     }
@@ -59,6 +62,8 @@ impl DeviceBuf<Fr> {
         let length = self.len();
         let mut result = DeviceBuf::<Fr>::async_alloc_in_exec(ctx, 1)?;
         ctx.exec_stream.wait(self.write_event())?;
+
+        assert!(self.data_is_set, "DeviceBuf should be filled with some data");
 
         let cfg = ff_poly_evaluate_configuration {
             mem_pool: ctx.mem_pool.unwrap(),
@@ -78,6 +83,7 @@ impl DeviceBuf<Fr> {
 
         self.read_event.record(ctx.exec_stream())?;
         result.write_event.record(ctx.exec_stream())?;
+        result.data_is_set = true;
 
         Ok(result)
     }
@@ -97,6 +103,8 @@ impl DeviceBuf<Fr> {
         for buffer in buffers.iter() {
             ctx.exec_stream.wait(buffer.write_event())?;
             ctx.exec_stream.wait(buffer.read_event())?;
+
+            assert!(buffer.data_is_set, "DeviceBuf should be filled with some data");
         }
 
         for i in 0..(buffers.len() - 1) {
@@ -221,6 +229,8 @@ impl DeviceBuf<Fr> {
             ctx[buffer_idx].exec_stream.wait(buffer.write_event())?;
             ctx[buffer_idx].exec_stream.wait(buffer.read_event())?;
 
+            assert!(buffer.data_is_set, "DeviceBuf should be filled with some data");
+
             let d_scalars = buffer.as_ptr(0..buffer.len());
 
             let cfg = ntt_configuration {
@@ -317,6 +327,8 @@ impl DeviceBuf<Fr> {
             ctx[ctx_id].exec_stream.wait(buffer.write_event())?;
             ctx[ctx_id].exec_stream.wait(buffer.read_event())?;
 
+            assert!(buffer.data_is_set, "DeviceBuf should be filled with some data");
+
             let d_scalars = buffer.as_ptr(0..buffer.len());
 
             let cfg = ntt_configuration {
@@ -380,6 +392,7 @@ impl DeviceBuf<Fr> {
         for buffer in buffers.iter() {
             ctx.exec_stream.wait(buffer.write_event())?;
             ctx.exec_stream.wait(buffer.read_event())?;
+            assert!(buffer.data_is_set, "DeviceBuf should be filled with some data");
         }
 
         for i in 0..(buffers.len() - 1) {
@@ -445,6 +458,7 @@ impl DeviceBuf<Fr> {
             set_device(device_id)?;
             ctx[buffer_idx].exec_stream.wait(buffer.write_event())?;
             ctx[buffer_idx].exec_stream.wait(buffer.read_event())?;
+            assert!(buffer.data_is_set, "DeviceBuf should be filled with some data");
 
             let d_scalars = buffer.as_ptr(0..buffer.len());
 

--- a/crates/gpu-prover/src/memory_manager/copying_operations.rs
+++ b/crates/gpu-prover/src/memory_manager/copying_operations.rs
@@ -59,11 +59,8 @@ impl<MC: ManagerConfigs> DeviceMemoryManager<Fr, MC> {
                                                                                //     .get_values_mut()
                                                                                //     .unwrap()
                                                                                //     .copy_from_slice(poly);
-        async_copy(
-            worker,
-            self.host_slots[host_idx].0.get_values_mut().unwrap(),
-            poly,
-        );
+        
+        self.host_slots[host_idx].0.async_copy_from_slice(worker, poly).unwrap();
 
         let idx = self.free_slot_idx().expect("No free slots");
 
@@ -123,7 +120,7 @@ impl<MC: ManagerConfigs> DeviceMemoryManager<Fr, MC> {
         async_copy(
             worker,
             poly,
-            self.host_slots[host_idx].0.get_values_mut().unwrap(),
+            self.host_slots[host_idx].0.get_values().unwrap(),
         );
 
         Ok(())

--- a/crates/gpu-prover/src/memory_manager/proving_operations/columns_sorting.rs
+++ b/crates/gpu-prover/src/memory_manager/proving_operations/columns_sorting.rs
@@ -278,6 +278,8 @@ fn sort_indexes<MC: ManagerConfigs>(
     stream.wait(buffers.2.write_event())?;
     stream.wait(buffers.2.read_event())?;
 
+    assert!(buffers.1.data_is_set, "DeviceBuf should be filled with some data");
+
     unsafe {
         let stream = manager.ctx[ctx_id].exec_stream.inner;
         let mem_pool = manager.ctx[ctx_id]
@@ -303,6 +305,7 @@ fn sort_indexes<MC: ManagerConfigs>(
     let mut stream = &mut manager.ctx[ctx_id].exec_stream;
     buffers.1.read_event.record(stream)?;
     buffers.2.write_event.record(stream)?;
+    buffers.2.data_is_set = true;
 
     Ok(())
 }
@@ -314,6 +317,9 @@ fn assign_columns<MC: ManagerConfigs>(
     offset_in_result: usize,
     ctx_id: usize,
 ) -> GpuResult<()> {
+    assert!(buffers.0.data_is_set, "DeviceBuf should be filled with some data");
+    assert!(buffers.2.data_is_set, "DeviceBuf should be filled with some data");
+
     let slot_idx = manager.get_slot_idx(PolyId::S, PolyForm::Values).unwrap();
     let device_id = manager.ctx[ctx_id].device_id();
     let stream = &mut manager.ctx[ctx_id].exec_stream;
@@ -352,6 +358,7 @@ fn assign_columns<MC: ManagerConfigs>(
                 res_buff.write_event.record(stream)?;
                 buffers.2.read_event.record(stream)?;
                 buffers.0.read_event.record(stream)?;
+                res_buff.data_is_set = true;
             }
 
             offset += range.len();

--- a/crates/gpu-prover/src/memory_manager/proving_operations/compute_assigments_and_permutations.rs
+++ b/crates/gpu-prover/src/memory_manager/proving_operations/compute_assigments_and_permutations.rs
@@ -89,6 +89,7 @@ fn create_buffers_for_computing_assigments_and_permutations<MC: ManagerConfigs>(
             len: MC::FULL_SLOT_SIZE,
             device_id: device_id_0,
 
+            data_is_set: false,
             is_static_mem: true,
             is_freed: true,
 
@@ -107,6 +108,7 @@ fn create_buffers_for_computing_assigments_and_permutations<MC: ManagerConfigs>(
         len: 4 * MC::FULL_SLOT_SIZE,
         device_id: device_id_1,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -121,6 +123,7 @@ fn create_buffers_for_computing_assigments_and_permutations<MC: ManagerConfigs>(
         len: 4 * MC::FULL_SLOT_SIZE,
         device_id: device_id_1,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -134,6 +137,7 @@ fn create_buffers_for_computing_assigments_and_permutations<MC: ManagerConfigs>(
         len: 4,
         device_id: device_id_1,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -153,6 +157,7 @@ fn create_buffers_for_computing_assigments_and_permutations<MC: ManagerConfigs>(
         len: assignments_len + 1,
         device_id: device_id_0,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -191,9 +196,10 @@ fn set_initial_values<MC: ManagerConfigs>(
     let num_non_residues = 4;
     let mut host_non_residues = AsyncVec::allocate_new(num_non_residues);
 
-    let mut host_buff = host_non_residues.get_values_mut()?;
-    host_buff[0] = Fr::one();
-    host_buff[1..].copy_from_slice(&make_non_residues::<Fr>(num_non_residues - 1));
+    let mut non_residues_buff = vec![Fr::one(); num_non_residues];
+    non_residues_buff[1..].copy_from_slice(&make_non_residues::<Fr>(num_non_residues - 1));
+
+    host_non_residues.copy_from_slice(&non_residues_buff)?;
 
     non_residues.async_copy_from_host(
         &mut manager.ctx[ctx_id_1],

--- a/crates/gpu-prover/src/memory_manager/proving_operations/compute_permutations.rs
+++ b/crates/gpu-prover/src/memory_manager/proving_operations/compute_permutations.rs
@@ -61,6 +61,7 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
         len: 4 * MC::FULL_SLOT_SIZE,
         device_id,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -74,6 +75,7 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
         len: 4 * MC::FULL_SLOT_SIZE,
         device_id,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -87,6 +89,7 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
         len: 4,
         device_id,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -99,9 +102,10 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
     let num_non_residues = 4;
     let mut host_non_residues = AsyncVec::allocate_new(num_non_residues);
 
-    let mut host_buff = host_non_residues.get_values_mut()?;
-    host_buff[0] = Fr::one();
-    host_buff[1..].copy_from_slice(&make_non_residues::<Fr>(num_non_residues - 1));
+    let mut non_residues_buff = vec![Fr::one(); num_non_residues];
+    non_residues_buff[1..].copy_from_slice(&make_non_residues::<Fr>(num_non_residues - 1));
+
+    host_non_residues.copy_from_slice(&non_residues_buff)?;
 
     non_residues.async_copy_from_host(
         &mut manager.ctx[ctx_id],
@@ -254,6 +258,7 @@ pub fn compute_permutation_polynomials_on_device(
     }
 
     permutations.write_event.record(&stream)?;
+    permutations.data_is_set = true;
 
     Ok(())
 }

--- a/crates/gpu-prover/src/memory_manager/proving_operations/compute_state_values.rs
+++ b/crates/gpu-prover/src/memory_manager/proving_operations/compute_state_values.rs
@@ -71,6 +71,7 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
             len: MC::FULL_SLOT_SIZE,
             device_id,
 
+            data_is_set: false,
             is_static_mem: true,
             is_freed: true,
 
@@ -85,6 +86,7 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
         len: 4 * MC::FULL_SLOT_SIZE,
         device_id,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -99,6 +101,7 @@ fn create_buffers_for_computing_assigments<MC: ManagerConfigs>(
         len: assignments_len + 1,
         device_id,
 
+        data_is_set: false,
         is_static_mem: true,
         is_freed: true,
 
@@ -255,6 +258,8 @@ pub fn assign_variables<MC: ManagerConfigs>(
     stream.wait(state_polys.write_event())?;
     stream.wait(variables.write_event())?;
     stream.wait(assigments.write_event())?;
+    assert!(variables.data_is_set, "DeviceBuf should be filled with some data");
+    assert!(assigments.data_is_set, "DeviceBuf should be filled with some data");
 
     let length = variables.len();
     let result = state_polys.as_mut_ptr(num_input_gates..length) as *mut c_void;
@@ -269,6 +274,7 @@ pub fn assign_variables<MC: ManagerConfigs>(
         };
     }
     state_polys.write_event.record(stream)?;
+    state_polys.data_is_set = true;
 
     Ok(())
 }

--- a/crates/gpu-prover/src/memory_manager/proving_operations/create_selectors.rs
+++ b/crates/gpu-prover/src/memory_manager/proving_operations/create_selectors.rs
@@ -329,6 +329,7 @@ pub fn create_selectors_inner(
     result_range: Range<usize>,
 ) -> GpuResult<()> {
     assert!(result_range.len() <= bitvec.len() * 256);
+    assert!(bitvec.data_is_set, "DeviceBuf should be filled with some data");
 
     ctx.exec_stream.wait(result.read_event())?;
     ctx.exec_stream.wait(result.write_event())?;
@@ -352,6 +353,7 @@ pub fn create_selectors_inner(
 
     result.write_event.record(ctx.exec_stream())?;
     bitvec.read_event.record(ctx.exec_stream())?;
+    result.data_is_set = true;
 
     Ok(())
 }


### PR DESCRIPTION
# What ❔

This PR adds `data_is_set` field to structures `AsyncVec` and `DeviceBuf` to track if inner data is correct and defined.

## Why ❔

Currently, it's possible to get access to uninitialized data. The simplest way is through `allocate_new` and `get_values` method of `AsyncVec`.