### PR TITLE
fix: bump `zksync-protocol` to 0.150.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ shivini = { version = "=0.151.0", path = "crates/shivini" }
 wrapper-prover = { version = "=0.151.0", path = "crates/wrapper-prover", package = "zksync-wrapper-prover" }
 
 # These dependencies should be shared by all the crates.
-circuit_definitions = { version = "=0.150.6" }
-zkevm_test_harness = { version = "=0.150.6" }
+circuit_definitions = { version = "=0.150.7" }
+zkevm_test_harness = { version = "=0.150.7" }
 boojum = "=0.30.1"
 franklin-crypto = "=0.30.1"


### PR DESCRIPTION
# What ❔

This PR bumps the dependencies from the `zksync-protocol` repo to version `0.150.7`

## Why ❔

`zkevm_test_harness` was updated to fix a problem with the `regex` crate.
See https://github.com/matter-labs/zksync-protocol/pull/51
