### PR TITLE
feat(boojum-cuda,shivini): implement GPU PoW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,15 @@ wrapper-prover = { version = "=0.152.6", path = "crates/wrapper-prover", package
 fflonk = { version = "=0.152.6", path = "crates/fflonk", package = "fflonk-cuda" }
 
 # These dependencies should be shared by all the crates.
-circuit_definitions = { version = "=0.150.14" }
-zkevm_test_harness = { version = "=0.150.14" }
+# zksync-crypto repository
 boojum = "=0.30.8"
+fflonk-cpu = {package = "fflonk", version = "=0.30.8"}
 franklin-crypto = "=0.30.8"
 rescue_poseidon = "=0.30.8"
 snark_wrapper = "=0.30.8"
-fflonk-cpu = {package = "fflonk", version = "=0.30.8"}
+# zksync-protocol repository
+circuit_definitions = { version = "=0.150.15" }
+zkevm_test_harness = { version = "=0.150.15" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/crates/proof-compression/src/gpu.rs
+++ b/crates/proof-compression/src/gpu.rs
@@ -20,7 +20,7 @@ use shivini::cs::GpuSetup;
 use shivini::gpu_proof_config::GpuProofConfig;
 use shivini::{
     gpu_prove_from_external_witness_data_with_cache_strategy, CacheStrategy,
-    CommitmentCacheStrategy, GpuTreeHasher, PolynomialsCacheStrategy, ProverContext,
+    CommitmentCacheStrategy, GPUPoWRunner, GpuTreeHasher, PolynomialsCacheStrategy, ProverContext,
     ProverContextConfig,
 };
 use std::alloc::Global;
@@ -369,7 +369,9 @@ pub fn prove_compression_wrapper_circuit_with_precomputations(
     (proof, vk)
 }
 
-pub fn inner_prove_compression_layer_circuit<CF: ProofCompressionFunction>(
+pub fn inner_prove_compression_layer_circuit<
+    CF: ProofCompressionFunction<ThisLayerPoW: GPUPoWRunner>,
+>(
     circuit: CompressionLayerCircuit<CF>,
     device_setup: &GpuSetup<CompressionProofsTreeHasher>,
     finalization_hint: FinalizationHintsForProver,
@@ -411,7 +413,9 @@ pub fn inner_prove_compression_layer_circuit<CF: ProofCompressionFunction>(
     (proof, vk)
 }
 
-pub fn inner_prove_compression_wrapper_circuit<CF: ProofCompressionFunction>(
+pub fn inner_prove_compression_wrapper_circuit<
+    CF: ProofCompressionFunction<ThisLayerPoW: GPUPoWRunner>,
+>(
     circuit: CompressionLayerCircuit<CF>,
     device_setup: &GpuSetup<CompressionTreeHasherForWrapper>,
     finalization_hint: FinalizationHintsForProver,

--- a/crates/shivini/Cargo.toml
+++ b/crates/shivini/Cargo.toml
@@ -24,8 +24,6 @@ smallvec = { version = "1.13", features = [
     "const_new",
     "serde",
 ] }
-sha2 = "0.10"
-blake2 = "0.10"
 hex = "0.4"
 derivative = "2.2"
 bincode = "1.3"

--- a/crates/shivini/src/data_structures/cache.rs
+++ b/crates/shivini/src/data_structures/cache.rs
@@ -7,7 +7,6 @@ use crate::poly::{CosetEvaluations, LagrangeBasis, MonomialBasis};
 use crate::prover::{
     compute_quotient_degree, gpu_prove_from_external_witness_data_with_cache_strategy,
 };
-use boojum::cs::implementations::pow::PoWRunner;
 use boojum::cs::implementations::prover::ProofConfig;
 use boojum::cs::implementations::transcript::Transcript;
 use boojum::cs::implementations::verifier::{VerificationKey, VerificationKeyCircuitGeometry};
@@ -736,7 +735,7 @@ impl CacheStrategy {
     pub(crate) fn get<
         TR: Transcript<F, CompatibleCap: Hash>,
         H: GpuTreeHasher<Output = TR::CompatibleCap>,
-        POW: PoWRunner,
+        POW: GPUPoWRunner,
         A: GoodAllocator,
     >(
         config: &GpuProofConfig,

--- a/crates/shivini/src/lib.rs
+++ b/crates/shivini/src/lib.rs
@@ -68,6 +68,7 @@ pub use context::ProverContextConfig;
 pub use data_structures::CacheStrategy;
 pub use data_structures::CommitmentCacheStrategy;
 pub use data_structures::PolynomialsCacheStrategy;
+pub use pow::GPUPoWRunner;
 pub use primitives::tree::GpuTreeHasher;
 pub use prover::gpu_prove_from_external_witness_data;
 pub use prover::gpu_prove_from_external_witness_data_with_cache_strategy;

--- a/crates/shivini/src/primitives/mod.rs
+++ b/crates/shivini/src/primitives/mod.rs
@@ -15,4 +15,3 @@ use era_cudart::slice::CudaSlice;
 use era_cudart::slice::DeviceSlice;
 pub use era_cudart::stream::CudaStream;
 use serde::{Deserialize, Serialize};
-pub use tree::GpuTreeHasher;

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "Zlib",
+    "Unicode-3.0",
 ]
 deny = [
     #"Nokia",


### PR DESCRIPTION
# What ❔

This PR implements GPU PoW for blake2s and poseidon2-bn254 and modifies shivini tu use it.

## Why ❔

PoW on GPU allows more aggressive use of PoW thereby reducing the proof time and/or verification complexity.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
