### PR TITLE
fix(cudart): recreate CUDA runtime bindings based on CUDA 13.0

### DIFF
--- a/crates/boojum-cuda/build/main.rs
+++ b/crates/boojum-cuda/build/main.rs
@@ -19,8 +19,8 @@ fn main() {
         use era_cudart_sys::{get_cuda_lib_path, get_cuda_version};
         let cuda_version =
             get_cuda_version().expect("Failed to determine the CUDA Toolkit version.");
-        if !cuda_version.starts_with("12.") {
-            println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit 12.*.");
+        if !(cuda_version.starts_with("12.") || cuda_version.starts_with("13.")) {
+            println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit versions 12.* and 13.*.");
         }
         let cudaarchs = std::env::var("CUDAARCHS").unwrap_or("native".to_string());
         let dst = cmake::Config::new("native")

--- a/crates/cudart-sys-bindings-generator/Cargo.toml
+++ b/crates/cudart-sys-bindings-generator/Cargo.toml
@@ -12,5 +12,5 @@ description = "CUDA Bindings generator for ZKsync"
 publish = false
 
 [dependencies]
-bindgen = "0.69"
+bindgen = "0.72"
 era_cudart_sys.workspace = true

--- a/crates/cudart-sys-bindings-generator/src/main.rs
+++ b/crates/cudart-sys-bindings-generator/src/main.rs
@@ -1,4 +1,4 @@
-use bindgen::callbacks::{EnumVariantValue, ParseCallbacks};
+use bindgen::callbacks::{EnumVariantValue, ItemInfo, ParseCallbacks};
 use bindgen::{BindgenError, Bindings};
 use era_cudart_sys::get_cuda_include_path;
 
@@ -47,9 +47,9 @@ impl ParseCallbacks for CudaParseCallbacks {
         }
     }
 
-    fn item_name(&self, _original_item_name: &str) -> Option<String> {
+    fn item_name(&self, item_info: ItemInfo) -> Option<String> {
         let from = |s: &str| Some(String::from(s));
-        match _original_item_name {
+        match item_info.name {
             "cudaDeviceAttr" => from("CudaDeviceAttr"),
             "cudaLimit" => from("CudaLimit"),
             "cudaError" => from("CudaError"),
@@ -106,7 +106,7 @@ fn generate_bindings<T: Into<String>>(header: T) -> Result<Bindings, BindgenErro
         .allowlist_function("cudaDeviceSynchronize")
         .allowlist_function("cudaGetDevice")
         .allowlist_function("cudaGetDeviceCount")
-        .allowlist_function("cudaGetDeviceProperties_v2")
+        .allowlist_function("cudaGetDeviceProperties")
         .allowlist_function("cudaSetDevice")
         // error handling
         // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__ERROR.html

--- a/crates/cudart-sys/build.rs
+++ b/crates/cudart-sys/build.rs
@@ -10,8 +10,8 @@ fn main() {
     } else {
         let cuda_version =
             get_cuda_version().expect("Failed to determine the CUDA Toolkit version.");
-        if !cuda_version.starts_with("12.") {
-            println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit version 12.*.");
+        if !(cuda_version.starts_with("12.") || cuda_version.starts_with("13.")) {
+            println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit versions 12.* and 13.*.");
         }
         let cuda_lib_path = get_cuda_lib_path().unwrap();
         let cuda_lib_path_str = cuda_lib_path.to_str().unwrap();

--- a/crates/cudart/src/device.rs
+++ b/crates/cudart/src/device.rs
@@ -33,7 +33,7 @@ pub fn get_device() -> CudaResult<i32> {
 
 pub fn get_device_properties(device_id: i32) -> CudaResult<CudaDeviceProperties> {
     let mut props = MaybeUninit::<CudaDeviceProperties>::uninit();
-    unsafe { cudaGetDeviceProperties_v2(props.as_mut_ptr(), device_id).wrap_maybe_uninit(props) }
+    unsafe { cudaGetDeviceProperties(props.as_mut_ptr(), device_id).wrap_maybe_uninit(props) }
 }
 
 pub fn set_device(device_id: i32) -> CudaResult<()> {

--- a/crates/gpu-ffi/build.rs
+++ b/crates/gpu-ffi/build.rs
@@ -11,8 +11,8 @@ fn main() {
     } else {
         let cuda_version =
             get_cuda_version().expect("Failed to determine the CUDA Toolkit version.");
-        if !cuda_version.starts_with("12.") {
-            println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit version 12.*.");
+        if !(cuda_version.starts_with("12.") || cuda_version.starts_with("13.")) {
+            println!("cargo::warning=CUDA Toolkit version {cuda_version} detected. This crate is only tested with CUDA Toolkit versions 12.* and 13.*.");
         }
         let bellman_cuda_dir = var("BELLMAN_CUDA_DIR").unwrap();
         let bellman_cuda_path = Path::new(&bellman_cuda_dir);


### PR DESCRIPTION
# What ❔

This PR recreates the CUDA runtime bindings based on CUDA toolkit version 13.0.

## Why ❔

The bindings based on CUDA toolkit version 12.x used `cudaGetDeviceProperties_v2` function which was removed in version 13, instead `cudaGetDeviceProperties` is used.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
