### PR TITLE
chore(ci): do not try to run CUDA 13 tests in CI until runner is CUDA 13 capable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-24.04-github-hosted-32core]
     strategy:
       matrix:
-        cuda: [ "12.0.0-devel-ubuntu20.04", "13.0.0-devel-ubuntu24.04" ]
+        cuda: [ "12.0.0-devel-ubuntu22.04", "12.9.1-devel-ubuntu22.04", "13.0.0-devel-ubuntu24.04" ]
     container:
       image: nvidia/cuda:${{ matrix.cuda }}
     env:

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     strategy:
       matrix:
-        cuda: [ "12.0.0-devel-ubuntu20.04", "13.0.0-devel-ubuntu24.04" ]
+        cuda: [ "12.0.0-devel-ubuntu22.04", "12.9.1-devel-ubuntu22.04", "13.0.0-devel-ubuntu24.04" ]
         # TODO: Building the whole workspace with `--test` currently fails with link-time errors,
         # presumably due to either `gpu-ffi` or `gpu-prover` crates.
         # So for now we point at specific packages we want to test.
@@ -93,6 +93,8 @@ jobs:
     runs-on: [ matterlabs-ci-gpu-runner ]
     strategy:
       matrix:
+        cuda: [ "12.0.0-devel-ubuntu22.04", "12.9.1-devel-ubuntu22.04" ]
+        # TODO: CUDA 13.0.0 is not yet supported by matterlabs-ci-gpu-runner.
         package: [ "era_cudart", "boojum-cuda", "shivini" ]
     needs: zksync-crypto-gpu-build
     env:
@@ -119,27 +121,13 @@ jobs:
           tar xvfz bellman-cuda.tar.gz -C ./bellman-cuda
           tar xvfz bellman-cuda-source.tar.gz -C ./bellman-cuda --strip-components=1 --wildcards \*/src/
 
-      - name: Download test binary built with CUDA 12.0
+      - name: Download test binary
         uses: actions/download-artifact@v4
         with:
-          name: zksync-crypto-gpu-12.0.0-devel-ubuntu20.04-${{ matrix.package }}-test-binary
-          path: zksync-crypto-gpu-test-binary/12.0/
+          name: zksync-crypto-gpu-${{ matrix.cuda }}-${{ matrix.package }}-test-binary
+          path: zksync-crypto-gpu-test-binary/
 
-      - name: Download test binary built with CUDA 13.0
-        uses: actions/download-artifact@v4
-        with:
-          name: zksync-crypto-gpu-13.0.0-devel-ubuntu24.04-${{ matrix.package }}-test-binary
-          path: zksync-crypto-gpu-test-binary/13.0/
-
-      - name: Run test binary built with CUDA 13.0
-        id: test_cuda_13_0
-        continue-on-error: true
+      - name: Run test binary
         run: |
-          chmod +x zksync-crypto-gpu-test-binary/13.0/${{ matrix.package }}
-          zksync-crypto-gpu-test-binary/13.0/${{ matrix.package }}
-
-      - name: Run test binary built with CUDA 12.0
-        if: steps.test_cuda_13_0.outcome == 'failure' || steps.test_cuda_13_0.outcome == 'success'
-        run: |
-          chmod +x zksync-crypto-gpu-test-binary/12.0/${{ matrix.package }}
-          zksync-crypto-gpu-test-binary/12.0/${{ matrix.package }}
+          chmod +x zksync-crypto-gpu-test-binary/${{ matrix.package }}
+          zksync-crypto-gpu-test-binary/${{ matrix.package }}


### PR DESCRIPTION
# What ❔

This PR changes the CI so that the binaries are build but not tested with CUDA 13, instead only CUDA 12.0.0 and 12.9.1 binaries are tested.

## Why ❔

The  GPU CI runner does not support CUDA 13 yet so the CUDA 13 binaries can not be tested.
