### PR TITLE
chore: updating to most recent booju,m, and making more public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,15 @@ wrapper-prover = { version = "=0.154.6", path = "crates/wrapper-prover", package
 
 # These dependencies should be shared by all the crates.
 # zksync-crypto repository
-boojum = "=0.32.1"
-fflonk-cpu = {package = "fflonk", version = "=0.32.1"}
-franklin-crypto = "=0.32.1"
-rescue_poseidon = "=0.32.1"
-snark_wrapper = "=0.32.1"
+boojum = "=0.32.2"
+fflonk-cpu = {package = "fflonk", version = "=0.32.2"}
+franklin-crypto = "=0.32.2"
+rescue_poseidon = "=0.32.2"
+snark_wrapper = "=0.32.2"
 
 # zksync-protocol repository
-circuit_definitions = { version = "=0.152.4" }
-zkevm_test_harness = { version = "=0.152.4" }
+circuit_definitions = { version = "=0.152.5" }
+zkevm_test_harness = { version = "=0.152.5" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/crates/proof-compression/src/lib.rs
+++ b/crates/proof-compression/src/lib.rs
@@ -7,7 +7,7 @@ pub use chain::*;
 pub mod proof_system;
 pub use proof_system::*;
 
-mod serialization;
+pub mod serialization;
 use serialization::*;
 
 pub mod step;

--- a/crates/proof-compression/src/proof_system/crs.rs
+++ b/crates/proof-compression/src/proof_system/crs.rs
@@ -271,6 +271,6 @@ fn create_crs_from_ignition_transcript<S: AsRef<std::ffi::OsStr> + ?Sized>(
     Ok(new)
 }
 
-pub(crate) fn hardcoded_canonical_g2_bases() -> [bellman::bn256::G2Affine; 2] {
+pub fn hardcoded_canonical_g2_bases() -> [bellman::bn256::G2Affine; 2] {
     ::fflonk::hardcoded_g2_bases::<bellman::bn256::Bn256>()
 }


### PR DESCRIPTION
# What ❔

* Updating dependencies to the most recent ones (especially boojum ones)
* making parts of the proof compression more public

# Why ?

Will allow us to run GPU for zkos wrapper.
