### PR TITLE
feat: Make setup_data cloneable

### DIFF
--- a/crates/gpu-prover/src/cuda_bindings/async_vec.rs
+++ b/crates/gpu-prover/src/cuda_bindings/async_vec.rs
@@ -3,6 +3,7 @@ use bellman::PrimeField;
 use core::ops::Range;
 use std::io::{Read, Write};
 
+#[derive(Clone)]
 pub struct AsyncVec<T, #[cfg(feature = "allocator")] A: Allocator = CudaAllocator> {
     #[cfg(feature = "allocator")]
     pub values: Option<Vec<T, A>>,

--- a/crates/gpu-prover/src/cuda_bindings/event.rs
+++ b/crates/gpu-prover/src/cuda_bindings/event.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-// #[derive(Clone)]
+#[derive(Debug)]
 pub struct Event {
     pub(crate) sub_events: Mutex<Vec<Vec<(usize, Arc<bc_event>)>>>,
 }

--- a/crates/gpu-prover/src/setup_precomputations.rs
+++ b/crates/gpu-prover/src/setup_precomputations.rs
@@ -28,6 +28,7 @@ use cfg_if::*;
 
 cfg_if! {
     if #[cfg(feature = "allocator")]{
+        #[derive(Clone)]
         pub struct AsyncSetup<A: Allocator = CudaAllocator> {
             pub gate_setup_monomials: [AsyncVec<Fr, A>; NUM_GATE_SETUP_POLYS],
             pub gate_selectors_bitvecs: [BitVec; NUM_SELECTOR_POLYS],
@@ -40,6 +41,7 @@ cfg_if! {
         unsafe impl<A: Allocator + Default> Send for AsyncSetup<A> {}
         unsafe impl<A: Allocator + Default> Sync for AsyncSetup<A> {}
     }else{
+        #[derive(Clone)]
         pub struct AsyncSetup{
             pub gate_setup_monomials: [AsyncVec<Fr>; NUM_GATE_SETUP_POLYS],
             pub gate_selectors_bitvecs: [BitVec; NUM_SELECTOR_POLYS],

--- a/crates/proof-compression/src/serialization.rs
+++ b/crates/proof-compression/src/serialization.rs
@@ -48,6 +48,7 @@ impl<H: GpuTreeHasher> shivini::boojum::cs::implementations::fast_serialization:
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PlonkSnarkVerifierCircuitDeviceSetupWrapper(pub PlonkSnarkVerifierCircuitDeviceSetup);
 
 impl MemcopySerializable for PlonkSnarkVerifierCircuitDeviceSetupWrapper {


### PR DESCRIPTION
Current PLONK SNARK setup data and VK (the same per cycle) can't be used by reference. setup_data is mutably changed & the structure is not cloneable. This leaves us with a set of options:
1. compute the setup data for each proof (slow runtime)
2. compute it once, save it to disk and load it from disk (fast implementation, not optimal; more of a hack)
3. refactor the code to use setup_data as reference (the "right" fix, but very difficult & time-consuming refactoring)
4. make the setup data cloneable, compute it at start and clone it on subsequent calls (pragmatic option)

4 was chosen and this PR contains the changes needed to make it happen
  (including some nice `Debug` derives)

