### PR TITLE
fix: avoid mut reference in proof and fixed Clone impl

### DIFF
--- a/crates/gpu-prover/src/cuda_bindings/async_vec.rs
+++ b/crates/gpu-prover/src/cuda_bindings/async_vec.rs
@@ -183,30 +183,6 @@ impl<T: fmt::Debug> fmt::Debug for AsyncVec<T> {
 }
 
 #[cfg(feature = "allocator")]
-impl<T: Clone, A: Allocator + Default> Clone for AsyncVec<T, A> {
-    fn clone(&self) -> Self {
-        let length = self.len();
-        let mut result = Self::allocate_new(length);
-
-        result.get_values_mut().unwrap().clone_from_slice(self.get_values().unwrap());
-
-        result
-    }
-}
-
-#[cfg(not(feature = "allocator"))]
-impl<T> Clone for AsyncVec<T> {
-    fn clone(&self) -> Self {
-        let length = self.len();
-        let mut result = Self::allocate_new(length);
-
-        result.get_values_mut().unwrap().copy_from_slice(self.get_values().unwrap());
-
-        result
-    }
-}
-
-#[cfg(feature = "allocator")]
 impl<T, A: Allocator> From<Vec<T, A>> for AsyncVec<T, A> {
     fn from(values: Vec<T, A>) -> Self {
         Self {

--- a/crates/gpu-prover/src/cuda_bindings/event.rs
+++ b/crates/gpu-prover/src/cuda_bindings/event.rs
@@ -21,7 +21,7 @@ impl Event {
         }
     }
 
-    pub fn record(&mut self, stream: &Stream) -> GpuResult<()> {
+    pub fn record(&self, stream: &Stream) -> GpuResult<()> {
         let device_id = stream.device_id();
         let stream_id = stream.inner.handle as usize;
         set_device(device_id)?;

--- a/crates/gpu-prover/src/memory_manager/copying_operations.rs
+++ b/crates/gpu-prover/src/memory_manager/copying_operations.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 impl<MC: ManagerConfigs> DeviceMemoryManager<Fr, MC> {
     pub fn async_copy_to_device(
         &mut self,
-        poly: &mut AsyncVec<Fr>,
+        poly: &AsyncVec<Fr>,
         id: PolyId,
         form: PolyForm,
         range: Range<usize>,

--- a/crates/gpu-prover/src/proof.rs
+++ b/crates/gpu-prover/src/proof.rs
@@ -11,7 +11,7 @@ pub fn create_proof<
     assembly: &DefaultAssembly<S>,
     manager: &mut DeviceMemoryManager<Fr, MC>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     transcript_params: Option<T::InitializationParameters>,
 ) -> Result<Proof<Bn256, C>, ProvingError> {
     // if S::PRODUCE_SETUP {

--- a/crates/gpu-prover/src/rounds/round1.rs
+++ b/crates/gpu-prover/src/rounds/round1.rs
@@ -6,7 +6,7 @@ pub fn round1<S: SynthesisMode, C: Circuit<Bn256>, T: Transcript<Fr>, MC: Manage
     worker: &Worker,
     proof: &mut Proof<Bn256, C>,
     transcript: &mut T,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     msm_handles_round1: &mut Vec<MSMHandle>,
 ) -> Result<(), ProvingError> {
     schedule_state_commitments::<S, _>(manager, worker, setup, msm_handles_round1)?;
@@ -24,7 +24,7 @@ pub fn round1<S: SynthesisMode, C: Circuit<Bn256>, T: Transcript<Fr>, MC: Manage
 fn schedule_state_commitments<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     msm_handles_round1: &mut Vec<MSMHandle>,
 ) -> Result<(), ProvingError> {
     let state_polys_ids = [PolyId::A, PolyId::B, PolyId::C, PolyId::D];
@@ -42,7 +42,7 @@ fn upload_t_poly_parts<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     if !S::PRODUCE_SETUP {
         let copy_start = MC::FULL_SLOT_SIZE - setup.lookup_tables_values[0].len() - 1;
@@ -150,7 +150,7 @@ fn upload_lookup_selector_and_table_type<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     if !S::PRODUCE_SETUP {
         // manager.async_copy_to_device(
@@ -166,7 +166,7 @@ fn upload_lookup_selector_and_table_type<S: SynthesisMode, MC: ManagerConfigs>(
         );
 
         manager.async_copy_to_device(
-            &mut setup.lookup_table_type_monomial,
+            &setup.lookup_table_type_monomial,
             PolyId::QTableType,
             PolyForm::Monomial,
             0..MC::FULL_SLOT_SIZE,
@@ -183,7 +183,7 @@ fn upload_lookup_selector_and_table_type<S: SynthesisMode, MC: ManagerConfigs>(
 
 fn schedule_auxiliary_operations<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     if !S::PRODUCE_SETUP {
         // manager.multigpu_fft(PolyId::QLookupSelector, false)?;

--- a/crates/gpu-prover/src/rounds/round15.rs
+++ b/crates/gpu-prover/src/rounds/round15.rs
@@ -7,7 +7,7 @@ pub fn round15<S: SynthesisMode, C: Circuit<Bn256>, T: Transcript<Fr>, MC: Manag
     proof: &mut Proof<Bn256, C>,
     constants: &mut ProverConstants<Fr>,
     transcript: &mut T,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     msm_handles_round1: Vec<MSMHandle>,
 ) -> Result<(), ProvingError> {
     for (i, commitment) in msm_handles_round1.into_iter().enumerate() {

--- a/crates/gpu-prover/src/rounds/round2.rs
+++ b/crates/gpu-prover/src/rounds/round2.rs
@@ -7,7 +7,7 @@ pub fn round2<S: SynthesisMode, C: Circuit<Bn256>, T: Transcript<Fr>, MC: Manage
     proof: &mut Proof<Bn256, C>,
     constants: &mut ProverConstants<Fr>,
     transcript: &mut T,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     input_values: &Vec<Fr>,
 ) -> Result<(), ProvingError> {
     get_round_2_permutation_challenges(constants, transcript);
@@ -268,7 +268,7 @@ pub fn schedule_ops_for_round_3<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     input_values: &Vec<Fr>,
 ) -> Result<(), ProvingError> {
     let len = input_values.len();
@@ -289,7 +289,7 @@ pub fn schedule_copying_gate_coeffs<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     if !S::PRODUCE_SETUP {
         copying_and_computing_q_const_plus_pi_with_setup(manager, setup)?;
@@ -304,10 +304,10 @@ pub fn schedule_copying_gate_coeffs<S: SynthesisMode, MC: ManagerConfigs>(
 
 pub fn copying_and_computing_q_const_plus_pi_with_setup<MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     manager.async_copy_to_device(
-        &mut setup.gate_setup_monomials[6],
+        &setup.gate_setup_monomials[6],
         PolyId::QConst,
         PolyForm::Monomial,
         0..MC::FULL_SLOT_SIZE,
@@ -325,7 +325,7 @@ pub fn copying_and_computing_q_const_plus_pi_with_setup<MC: ManagerConfigs>(
 pub fn copying_and_computing_ifft_of_gate_coeffs<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     manager.free_host_slot(PolyId::PI, PolyForm::Values);
 
@@ -341,7 +341,7 @@ pub fn copying_and_computing_q_const_plus_pi<S: SynthesisMode, MC: ManagerConfig
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     copying_setup_poly(manager, &assembly, 6);
 
@@ -356,7 +356,7 @@ pub fn copying_and_computing_q_const_plus_pi<S: SynthesisMode, MC: ManagerConfig
 pub fn copying_and_computing_ifft_of_q_d_next<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     copying_setup_poly(manager, assembly, 7);
     manager.multigpu_ifft(GATE_SETUP_LIST[7], false)?;

--- a/crates/gpu-prover/src/rounds/round3.rs
+++ b/crates/gpu-prover/src/rounds/round3.rs
@@ -7,7 +7,7 @@ pub fn round3<S: SynthesisMode, C: Circuit<Bn256>, T: Transcript<Fr>, MC: Manage
     proof: &mut Proof<Bn256, C>,
     constants: &mut ProverConstants<Fr>,
     transcript: &mut T,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     get_round_3_challenges(constants, transcript);
 
@@ -54,7 +54,7 @@ pub fn compute_main_custom_and_permutation_gates<S: SynthesisMode, MC: ManagerCo
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
     constants: &mut ProverConstants<Fr>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     if S::PRODUCE_SETUP {
         compute_gate_selector_monomials(manager, assembly, worker)?;
@@ -159,7 +159,7 @@ pub fn copy_polynomials_for_main_custom_and_permutation_gates<
     MC: ManagerConfigs,
 >(
     manager: &mut DeviceMemoryManager<Fr, MC>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     coset_idx: usize,
 ) -> Result<(), ProvingError> {
     let poly_ids = [
@@ -187,13 +187,13 @@ pub fn copy_polynomials_for_main_custom_and_permutation_gates<
 
 pub fn copy_monomials_from_setup_for_main_custom_and_permutation_gates<MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     poly_ids: [PolyId; 7],
     coset_idx: usize,
 ) -> Result<(), ProvingError> {
     for (i, id) in poly_ids[..6].iter().enumerate() {
         manager.async_copy_to_device(
-            &mut setup.gate_setup_monomials[i],
+            &setup.gate_setup_monomials[i],
             *id,
             PolyForm::Monomial,
             0..MC::FULL_SLOT_SIZE,
@@ -202,7 +202,7 @@ pub fn copy_monomials_from_setup_for_main_custom_and_permutation_gates<MC: Manag
     }
 
     manager.async_copy_to_device(
-        &mut setup.gate_setup_monomials[7],
+        &setup.gate_setup_monomials[7],
         PolyId::QDNext,
         PolyForm::Monomial,
         0..MC::FULL_SLOT_SIZE,
@@ -579,7 +579,7 @@ pub fn compute_lookup_gate<S: SynthesisMode, MC: ManagerConfigs>(
     assembly: &DefaultAssembly<S>,
     worker: &Worker,
     constants: &mut ProverConstants<Fr>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
 ) -> Result<(), ProvingError> {
     compute_shifted_lookup_polynomials(manager)?;
 
@@ -640,7 +640,7 @@ pub fn compute_lookup_gate<S: SynthesisMode, MC: ManagerConfigs>(
             manager.multigpu_ifft(PolyId::QLookupSelector, false)?;
             manager.multigpu_coset_fft(PolyId::QLookupSelector, coset_idx)?;
             manager.async_copy_to_device(
-                &mut setup.lookup_table_type_monomial,
+                &setup.lookup_table_type_monomial,
                 PolyId::QTableType,
                 PolyForm::Monomial,
                 0..MC::FULL_SLOT_SIZE,
@@ -958,7 +958,7 @@ pub fn compute_quotient_monomial_and_schedule_commitments<MC: ManagerConfigs>(
 pub fn schedule_monomial_copyings_for_last_rounds<S: SynthesisMode, MC: ManagerConfigs>(
     manager: &mut DeviceMemoryManager<Fr, MC>,
     assembly: &DefaultAssembly<S>,
-    setup: &mut AsyncSetup,
+    setup: &AsyncSetup,
     worker: &Worker,
 ) -> Result<(), ProvingError> {
     if S::PRODUCE_SETUP {
@@ -991,7 +991,7 @@ pub fn schedule_monomial_copyings_for_last_rounds<S: SynthesisMode, MC: ManagerC
         manager.multigpu_ifft(PolyId::QLookupSelector, false)?;
 
         manager.async_copy_to_device(
-            &mut setup.lookup_table_type_monomial,
+            &setup.lookup_table_type_monomial,
             PolyId::QTableType,
             PolyForm::Monomial,
             0..MC::FULL_SLOT_SIZE,
@@ -999,7 +999,7 @@ pub fn schedule_monomial_copyings_for_last_rounds<S: SynthesisMode, MC: ManagerC
 
         for (i, poly_id) in GATE_SETUP_LIST.iter().enumerate() {
             manager.async_copy_to_device(
-                &mut setup.gate_setup_monomials[i],
+                &setup.gate_setup_monomials[i],
                 *poly_id,
                 PolyForm::Monomial,
                 0..MC::FULL_SLOT_SIZE,

--- a/crates/gpu-prover/src/setup_precomputations.rs
+++ b/crates/gpu-prover/src/setup_precomputations.rs
@@ -40,7 +40,6 @@ cfg_if! {
         unsafe impl<A: Allocator + Default> Send for AsyncSetup<A> {}
         unsafe impl<A: Allocator + Default> Sync for AsyncSetup<A> {}
     }else{
-        #[derive(Clone)]
         pub struct AsyncSetup{
             pub gate_setup_monomials: [AsyncVec<Fr>; NUM_GATE_SETUP_POLYS],
             pub gate_selectors_bitvecs: [BitVec; NUM_SELECTOR_POLYS],

--- a/crates/gpu-prover/src/setup_precomputations.rs
+++ b/crates/gpu-prover/src/setup_precomputations.rs
@@ -29,7 +29,7 @@ use cfg_if::*;
 cfg_if! {
     if #[cfg(feature = "allocator")]{
         #[derive(Clone)]
-        pub struct AsyncSetup<A: Allocator = CudaAllocator> {
+        pub struct AsyncSetup<A: Allocator + Default = CudaAllocator> {
             pub gate_setup_monomials: [AsyncVec<Fr, A>; NUM_GATE_SETUP_POLYS],
             pub gate_selectors_bitvecs: [BitVec; NUM_SELECTOR_POLYS],
 

--- a/crates/gpu-prover/src/setup_precomputations.rs
+++ b/crates/gpu-prover/src/setup_precomputations.rs
@@ -28,7 +28,6 @@ use cfg_if::*;
 
 cfg_if! {
     if #[cfg(feature = "allocator")]{
-        #[derive(Clone)]
         pub struct AsyncSetup<A: Allocator + Default = CudaAllocator> {
             pub gate_setup_monomials: [AsyncVec<Fr, A>; NUM_GATE_SETUP_POLYS],
             pub gate_selectors_bitvecs: [BitVec; NUM_SELECTOR_POLYS],

--- a/crates/proof-compression/src/serialization.rs
+++ b/crates/proof-compression/src/serialization.rs
@@ -48,7 +48,7 @@ impl<H: GpuTreeHasher> shivini::boojum::cs::implementations::fast_serialization:
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PlonkSnarkVerifierCircuitDeviceSetupWrapper(pub PlonkSnarkVerifierCircuitDeviceSetup);
 
 impl MemcopySerializable for PlonkSnarkVerifierCircuitDeviceSetupWrapper {


### PR DESCRIPTION
# What ❔

- avoid using mutable reference of AsyncVec to clone to device
- fixed Clone impl for AsyncVec
- using &AsyncSetup in prover
