### PR TITLE
feat!: Bump zksync-protocol dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ rescue_poseidon = "=0.32.3"
 snark_wrapper = "=0.32.3"
 
 # zksync-protocol repository
-circuit_definitions = { version = "=0.152.7" }
-zkevm_test_harness = { version = "=0.152.7" }
+circuit_definitions = { version = "=0.153.0" }
+zkevm_test_harness = { version = "=0.153.0" }
 
 [profile.release]
 debug = "line-tables-only"


### PR DESCRIPTION
Bumps from 0.152.7 to 0.153.0, namely:
- `circuit_definitions`
- `zkevm_test_harness`

Allows using the latest changes.

