### PR TITLE
feat: Bump zksync-protocol dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ rescue_poseidon = "=0.32.3"
 snark_wrapper = "=0.32.3"
 
 # zksync-protocol repository
-circuit_definitions = { version = "=0.153.0" }
-zkevm_test_harness = { version = "=0.153.0" }
+circuit_definitions = { version = "=0.153.1" }
+zkevm_test_harness = { version = "=0.153.1" }
 
 [profile.release]
 debug = "line-tables-only"


### PR DESCRIPTION
Bumps `circuit_definitions` and `zkevm_test_harness` to 0.153.1. This allows unpinning sha2, which is useful for using the crate in both zksync-era (sha2@0.10.8) & zksync-os-server (sha2@0.10.9).

