### PR TITLE
fix: add operator+= to offset_iterator for CUDA 13.2 / CCCL 3.x

### DIFF
--- a/crates/boojum-cuda/native/ops_cub/device_reduce.cu
+++ b/crates/boojum-cuda/native/ops_cub/device_reduce.cu
@@ -11,10 +11,14 @@ struct offset_iterator {
   using reference = int &;
 #endif
 
-  const int offset;
+  int offset;
   const int stride;
 
   DEVICE_FORCEINLINE int operator[](const int idx) const { return offset + idx * stride; }
+  DEVICE_FORCEINLINE offset_iterator &operator+=(const int idx) {
+    offset += idx * stride;
+    return *this;
+  }
 };
 
 using namespace goldilocks;


### PR DESCRIPTION
# What ❔

Adds `operator+=` to `offset_iterator` in [crates/boojum-cuda/native/ops_cub/device_reduce.cu](crates/boojum-cuda/native/ops_cub/device_reduce.cu) and drops `const` on its `offset` member.

## Why ❔

CUDA 13.2 ships CCCL 3.x, whose `DeviceSegmentedReduce::Reduce` multi-invocation dispatch mutates the user-supplied begin/end offset iterators via `+=`. The previous immutable iterator had no `+=`, so `boojum-cuda` failed to build on CUDA 13.2. Source-compatible with CUDA 12.x.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.