### PR TITLE
fix!: remove UB in DeviceSlice::empty() that miscompiled shivini prover

### DIFF
--- a/crates/boojum-cuda/src/ops_cub/device_radix_sort.rs
+++ b/crates/boojum-cuda/src/ops_cub/device_radix_sort.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use boojum::field::goldilocks::GoldilocksField;
 
@@ -79,17 +79,17 @@ pub trait SortKeys: Sized {
         begin_bit: i32,
         end_bit: i32,
     ) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
         let mut temp_storage_bytes = 0;
-        let d_keys_in = DeviceSlice::empty();
-        let d_keys_out = DeviceSlice::empty_mut();
         let function = Self::get_function(descending);
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_keys_in.as_ptr(),
-                d_keys_out.as_mut_ptr(),
+                null(),
+                null_mut(),
                 num_items,
                 begin_bit,
                 end_bit,
@@ -348,21 +348,19 @@ pub trait SortPairs<K, V> {
         begin_bit: i32,
         end_bit: i32,
     ) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
         let mut temp_storage_bytes = 0;
-        let d_keys_in = DeviceSlice::empty();
-        let d_keys_out = DeviceSlice::empty_mut();
-        let d_values_in = DeviceSlice::empty();
-        let d_values_out = DeviceSlice::empty_mut();
         let function = Self::get_function(descending);
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_keys_in.as_ptr(),
-                d_keys_out.as_mut_ptr(),
-                d_values_in.as_ptr(),
-                d_values_out.as_mut_ptr(),
+                null(),
+                null_mut(),
+                null(),
+                null_mut(),
                 num_items,
                 begin_bit,
                 end_bit,

--- a/crates/boojum-cuda/src/ops_cub/device_run_length_encode.rs
+++ b/crates/boojum-cuda/src/ops_cub/device_run_length_encode.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use boojum::field::goldilocks::GoldilocksField;
 
@@ -48,21 +48,20 @@ pub trait Encode: Sized {
     fn get_function() -> EncodeFunction<Self>;
 
     fn get_encode_temp_storage_bytes(num_items: i32) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
+        // The other pointer arguments are likewise ignored in this mode.
         let mut temp_storage_bytes = 0;
-        let d_in = DeviceSlice::empty();
-        let d_unique_out = DeviceSlice::empty_mut();
-        let d_counts_out = DeviceSlice::empty_mut();
-        let d_num_runs_out = DeviceSlice::empty_mut();
         let function = Self::get_function();
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_in.as_ptr(),
-                d_unique_out.as_mut_ptr(),
-                d_counts_out.as_mut_ptr(),
-                d_num_runs_out.as_mut_ptr(),
+                null(),
+                null_mut(),
+                null_mut(),
+                null_mut(),
                 num_items,
                 null_mut(),
             )

--- a/crates/boojum-cuda/src/ops_cub/device_scan.rs
+++ b/crates/boojum-cuda/src/ops_cub/device_scan.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use boojum::field::goldilocks::GoldilocksField;
 
@@ -255,17 +255,17 @@ pub trait Scan: Sized {
         reverse: bool,
         num_items: i32,
     ) -> CudaResult<usize> {
-        let d_temp_storage = DeviceSlice::empty_mut();
+        // CUB convention: `d_temp_storage == nullptr` puts the call in
+        // size-query mode — CUB writes the required scratch size into
+        // `temp_storage_bytes` and returns without touching any data pointer.
         let mut temp_storage_bytes = 0;
-        let d_in = DeviceSlice::empty();
-        let d_out = DeviceSlice::empty_mut();
         let function = Self::get_function(operation, inclusive, reverse);
         unsafe {
             function(
-                d_temp_storage.as_mut_ptr(),
+                null_mut(),
                 &mut temp_storage_bytes,
-                d_in.as_ptr(),
-                d_out.as_mut_ptr(),
+                null(),
+                null_mut(),
                 num_items,
                 null_mut(),
             )

--- a/crates/cudart/src/slice/device_slice.rs
+++ b/crates/cudart/src/slice/device_slice.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Formatter};
 use std::mem::size_of;
 use std::ptr;
-use std::ptr::{null, null_mut};
+use std::ptr::NonNull;
 
 use crate::slice::iter::{Chunks, ChunksMut};
 use crate::slice::AllocationData;
@@ -44,11 +44,21 @@ impl<T> DeviceSlice<T> {
     }
 
     pub fn empty<'a>() -> &'a Self {
-        unsafe { Self::from_raw_parts(null(), 0) }
+        // Zero-length slices must be backed by a non-null, properly aligned
+        // pointer — a null pointer would make the resulting `&DeviceSlice<T>`
+        // UB even without dereferencing, and LLVM exploits that to miscompile
+        // callers that branch on `len == 0`. `NonNull::dangling()` is the
+        // Rust-idiomatic choice for an empty slice and is never dereferenced.
+        // Callers that previously relied on this pointer being null (e.g. to
+        // trigger CUB's size-query convention) must now pass `null_mut()`
+        // explicitly at the FFI boundary.
+        let ptr = NonNull::<T>::dangling().as_ptr() as *const T;
+        unsafe { Self::from_raw_parts(ptr, 0) }
     }
 
     pub fn empty_mut<'a>() -> &'a mut Self {
-        unsafe { Self::from_raw_parts_mut(null_mut(), 0) }
+        let ptr = NonNull::<T>::dangling().as_ptr();
+        unsafe { Self::from_raw_parts_mut(ptr, 0) }
     }
 
     pub fn as_ptr(&self) -> *const T {


### PR DESCRIPTION
# What ❔

Changes `DeviceSlice::empty()` / `empty_mut()` to use `NonNull::<T>::dangling()` instead of a null pointer, and refactors boojum-cuda's CUB size-query wrappers to pass `null_mut()` / `null()` explicitly at the FFI boundary.

## Why ❔

Constructing a Rust reference from a null pointer is UB even for zero-length slices. LLVM exploited this to deduce branch unreachability, miscompiling shivini's `compute_deep_quotiening_over_coset` into a spurious `assert_eq!(0, 0)` panic on lookup-free compression layers in SNARK compression.

`NonNull::dangling()` is the Rust-idiomatic non-null backing for empty slices. CUB size-query wrappers that previously relied on `DeviceSlice::empty()` returning a null pointer (to trigger CUB's `d_temp_storage == nullptr` convention) now pass `NULL` explicitly — self-documenting at the call site.

**Breaking**: external consumers depending on the null runtime value of `DeviceSlice::empty()` must pass `NULL` explicitly at the FFI boundary.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.